### PR TITLE
Bug fix/normal mapping

### DIFF
--- a/include/renderer/internal/vulkan/vulkan_swapchain.h
+++ b/include/renderer/internal/vulkan/vulkan_swapchain.h
@@ -11,6 +11,7 @@ typedef struct vulkan_image_t vulkan_image_t;
 typedef struct vulkan_swapchain_create_info_t
 {
 	VkFormat image_format;
+	VkFormat depth_format;
 	VkColorSpaceKHR image_color_space;
 	u32 image_count;
 	VkExtent2D image_extent;

--- a/include/renderer/internal/vulkan/vulkan_swapchain.h
+++ b/include/renderer/internal/vulkan/vulkan_swapchain.h
@@ -29,6 +29,7 @@ typedef struct vulkan_swapchain_t
 	VkImageView* image_views;
 	VkFramebuffer* framebuffers;
 	VkImageView* framebuffer_image_views;
+	VkExtent2D image_extent;
 	u32 image_count;
 	u32 current_image_index;
 	VkSemaphore image_available_semaphore;

--- a/include/renderer/internal/vulkan/vulkan_texture.h
+++ b/include/renderer/internal/vulkan/vulkan_texture.h
@@ -7,12 +7,19 @@
 typedef struct renderer_t renderer_t;
 typedef struct vulkan_image_t vulkan_image_t;
 
+typedef enum vulkan_texture_type_t
+{
+	VULKAN_TEXTURE_TYPE_ALBEDO = 0,
+	VULKAN_TEXTURE_TYPE_NORMAL
+} vulkan_texture_type_t;
+
 typedef struct vulkan_texture_create_info_t
 {
 	void* data;
 	u32 width;
 	u32 height;
 	u8 channel_count;
+	vulkan_texture_type_t type;
 } vulkan_texture_create_info_t;
 
 typedef struct vulkan_texture_t

--- a/include/renderer/texture.h
+++ b/include/renderer/texture.h
@@ -22,15 +22,22 @@ typedef vulkan_texture_t texture_t;
 
 #include <renderer/defines.h>
 
+typedef enum texture_type_t
+{
+	TEXTURE_TYPE_ALBEDO = 0,
+	TEXTURE_TYPE_NORMAL
+} texture_type_t;
+
 typedef struct texture_create_info_t
 {
 	void* data;
 	u32 width;
 	u32 height;
 	u8 channel_count;
+	texture_type_t type;
 } texture_create_info_t;
 
 texture_t* texture_create(renderer_t* renderer, texture_create_info_t* create_info);
-texture_t* texture_load(renderer_t* renderer, const char* file_path);
+texture_t* texture_load(renderer_t* renderer, const char* file_path, texture_type_t type);
 void texture_destroy(texture_t* texture, renderer_t* renderer);
 void texture_release_resources(texture_t* texture);

--- a/include/vulkan/vulkan_wrapper.h
+++ b/include/vulkan/vulkan_wrapper.h
@@ -149,12 +149,10 @@ function_signature(VkPipeline, vk_get_graphics_pipeline, VkDevice device, VkPipe
 function_signature(VkDescriptorSetLayout, vk_get_descriptor_set_layout, VkDevice device, VkDescriptorSetLayoutBinding* bindings, uint32_t binding_count);
 function_signature(VkDescriptorPool, vk_get_descriptor_pool, VkDevice device);
 function_signature(VkCommandPool, vk_get_command_pool, VkDevice device, uint32_t queueFamilyIndex);
-function_signature(VkAttachmentReference, vk_get_attachment_reference, uint32_t index, VkImageLayout layout);
 function_signature_void(VkSubpassDependency, vk_get_subpass_dependency);
 function_signature(VkSemaphore, vk_get_semaphore, VkDevice device);
-function_signature(VkAttachmentDescription, vk_get_attachment_description, VkAttachmentStoreOp store_op, VkImageLayout final_layout, VkFormat image_format);
 function_signature(VkSubpassDescription, vk_get_subpass_description, VkAttachmentReference* color_attachments, uint32_t color_attachment_count, VkAttachmentReference* depth_stencil_attachment);
-function_signature(VkRenderPass, vk_get_render_pass, VkDevice device, VkFormat format);
+function_signature(VkRenderPass, vk_get_render_pass, VkDevice device, VkFormat format, VkFormat depth_format);
 function_signature(VkPipelineLayout, vk_get_pipeline_layout, VkDevice device, uint32_t set_layout_count, VkDescriptorSetLayout* set_layouts, uint32_t push_constant_range_count, VkPushConstantRange* push_constant_ranges);
 function_signature(VkViewport, vk_get_viewport, uint32_t width, uint32_t height);
 function_signature(VkBuffer, vk_get_buffer, VkDevice device, VkDeviceSize size, VkBufferUsageFlags usageFlags, VkSharingMode sharingMode);
@@ -228,10 +226,8 @@ function_signature(void, vk_dump_physical_device_extensions, VkPhysicalDevice* p
 #define vk_get_descriptor_set_layout(...) define_alias_function_macro(vk_get_descriptor_set_layout, __VA_ARGS__)
 #define vk_get_descriptor_pool(...) define_alias_function_macro(vk_get_descriptor_pool, __VA_ARGS__)
 #define vk_get_command_pool(...) define_alias_function_macro(vk_get_command_pool, __VA_ARGS__)
-#define vk_get_attachment_reference(...) define_alias_function_macro(vk_get_attachment_reference, __VA_ARGS__)
 #define vk_get_subpass_dependency(...) define_alias_function_void_macro(vk_get_subpass_dependency)
 #define vk_get_semaphore(...) define_alias_function_macro(vk_get_semaphore, __VA_ARGS__)
-#define vk_get_attachment_description(...) define_alias_function_macro(vk_get_attachment_description, __VA_ARGS__)
 #define vk_get_subpass_description(...) define_alias_function_macro(vk_get_subpass_description, __VA_ARGS__)
 #define vk_get_render_pass(...) define_alias_function_macro(vk_get_render_pass, __VA_ARGS__)
 #define vk_get_pipeline_layout(...) define_alias_function_macro(vk_get_pipeline_layout, __VA_ARGS__)

--- a/source/renderer/texture.c
+++ b/source/renderer/texture.c
@@ -15,7 +15,7 @@ texture_t* texture_create(renderer_t* renderer, texture_create_info_t* create_in
 	return vulkan_texture_create(renderer, &vulkan_create_info);
 }
 
-texture_t* texture_load(renderer_t* renderer, const char* file_path)
+texture_t* texture_load(renderer_t* renderer, const char* file_path, texture_type_t type)
 {
 	bmp_t image = bmp_load(file_path);
 	vulkan_texture_create_info_t create_info =
@@ -23,7 +23,8 @@ texture_t* texture_load(renderer_t* renderer, const char* file_path)
 		.data = image.data,
 		.width = image.width,
 		.height = image.height,
-		.channel_count = image.channel_count
+		.channel_count = image.channel_count,
+		.type = (vulkan_texture_type_t)type
 	};
 	vulkan_texture_t* texture = vulkan_texture_create(renderer, &create_info);
 	bmp_destroy(image);

--- a/source/renderer/vulkan/vulkan_image.c
+++ b/source/renderer/vulkan/vulkan_image.c
@@ -155,6 +155,20 @@ VkImageView vulkan_image_get_image_view(vulkan_image_t* image)
 		.subresourceRange.baseArrayLayer = 0,
 		.subresourceRange.layerCount = 1
 	};
+
+	// swap the blue and red components with each other
+	switch(image->format)
+	{
+		case VK_FORMAT_R8G8B8A8_UNORM:
+    	case VK_FORMAT_R8G8B8A8_SNORM:
+    	case VK_FORMAT_R8G8B8A8_USCALED:
+    	case VK_FORMAT_R8G8B8A8_SSCALED:
+    	case VK_FORMAT_R8G8B8A8_UINT:
+    	case VK_FORMAT_R8G8B8A8_SINT:
+    	case VK_FORMAT_R8G8B8A8_SRGB:
+    		view_create_info.components = (VkComponentMapping) { VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R };
+    	break;
+	}
 	VkImageView image_view;
 	vkCall(vkCreateImageView(image->renderer->logical_device->handle, &view_create_info, NULL, &image_view));
 	return image_view;

--- a/source/renderer/vulkan/vulkan_renderer.c
+++ b/source/renderer/vulkan/vulkan_renderer.c
@@ -208,14 +208,23 @@ DEBUG_BLOCK
 	renderer->logical_device = vulkan_logical_device_create(physical_device, &logical_device_create_info);
 	heap_free(minimum_required_features);
 
+	// setup depth buffer format
+	VkFormat* formats = stack_newv(VkFormat, 3);
+	formats[0] = VK_FORMAT_D32_SFLOAT;
+	formats[1] = VK_FORMAT_D32_SFLOAT_S8_UINT;
+	formats[2] = VK_FORMAT_D24_UNORM_S8_UINT;
+	VkFormat depth_format = vk_find_supported_format(renderer->physical_device->handle, &formats[0], 3, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
+	stack_free(formats);
+
 	//Create Renderpass
-	renderer->vk_render_pass = vk_get_render_pass(renderer->logical_device->handle, VK_FORMAT_B8G8R8A8_SRGB);
+	renderer->vk_render_pass = vk_get_render_pass(renderer->logical_device->handle, surface_format.format, depth_format);
 
 	//Create Swapchain
 	vulkan_swapchain_create_info_t swapchain_info =
 	{
 		.image_count = image_count,
 		.image_format = surface_format.format,
+		.depth_format = depth_format,
 		.image_color_space = surface_format.colorSpace,
 		.image_extent = image_extent,
 		.image_sharing_mode = (queue_family_indices[0] == queue_family_indices[1]) ? VK_SHARING_MODE_EXCLUSIVE : VK_SHARING_MODE_CONCURRENT,

--- a/source/renderer/vulkan/vulkan_renderer.c
+++ b/source/renderer/vulkan/vulkan_renderer.c
@@ -256,7 +256,7 @@ void renderer_begin_frame(renderer_t* renderer, float r, float g, float b, float
 	{
 		.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
 		.renderArea.offset = (VkOffset2D) { 0, 0 },
-		.renderArea.extent = (VkExtent2D) { renderer->window->width, renderer->window->height },
+		.renderArea.extent = renderer->swapchain->image_extent,
 		.framebuffer = renderer->swapchain->framebuffers[renderer->swapchain->current_image_index],
 		.renderPass = renderer->vk_render_pass,
 		.clearValueCount = 2,

--- a/source/renderer/vulkan/vulkan_swapchain.c
+++ b/source/renderer/vulkan/vulkan_swapchain.c
@@ -86,8 +86,9 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 	};
 	swapchain->handle = vk_get_swapchain(renderer->logical_device->handle, &swapchain_create_info);
 	swapchain->image_count = create_info->image_count;
+	swapchain->image_extent = create_info->image_extent;
 	log_msg("Swapchain image count: %u\n", swapchain->image_count);
-	log_msg("Swapchain image size: (%u, %u)\n", create_info->image_extent.width, create_info->image_extent.height);
+	log_msg("Swapchain image size: (%u, %u)\n", swapchain->image_extent.width, swapchain->image_extent.height);
 
 	// if the swapchain has to be recreated then no allocation should happen, use *_out versions instead
 	if(swapchain->images == NULL)

--- a/source/renderer/vulkan/vulkan_swapchain.c
+++ b/source/renderer/vulkan/vulkan_swapchain.c
@@ -100,14 +100,10 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 		swapchain->image_views = vk_get_image_views(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images).value2;
 	else vk_get_image_views_out(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images, swapchain->image_views);
 
-	VkFormat* formats = stack_newv(VkFormat, 3);
-	formats[0] = VK_FORMAT_D32_SFLOAT;
-	formats[1] = VK_FORMAT_D32_SFLOAT_S8_UINT;
-	formats[2] = VK_FORMAT_D24_UNORM_S8_UINT;
 	vulkan_image_create_info_t depth_create_info = 
 	{
 		.type = VK_IMAGE_TYPE_2D,
-		.format = vk_find_supported_format(renderer->physical_device->handle, &formats[0], 3, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT),
+		.format = create_info->depth_format,
 		.width = create_info->image_extent.width,
 		.height = create_info->image_extent.height,
 		.depth = 1,
@@ -146,18 +142,17 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 	// if the swapchain has to be recreated then no allocation should happen, use *_out versions instead
 	if(swapchain->framebuffers == NULL)
 		swapchain->framebuffers = vk_get_framebuffers(	renderer->logical_device->handle, renderer->vk_render_pass, 
-														(VkExtent2D) { renderer->window->width, renderer->window->height },
+														swapchain->image_extent,
 														1,
 														&attachments_lists[0],
 														&attachments_count[0], swapchain->image_count).value2;
 	else
 		vk_get_framebuffers_out(	renderer->logical_device->handle, renderer->vk_render_pass, 
-									(VkExtent2D) { renderer->window->width, renderer->window->height }, 
+									swapchain->image_extent, 
 									1, 
 									&attachments_lists[0], &attachments_count[0], 
 									swapchain->image_count, swapchain->framebuffers);
 	swapchain->current_image_index = 0;
-	stack_free(formats);
 }
 
 

--- a/source/renderer/vulkan/vulkan_swapchain.c
+++ b/source/renderer/vulkan/vulkan_swapchain.c
@@ -36,63 +36,7 @@ vulkan_swapchain_t* vulkan_swapchain_create(renderer_t* renderer, vulkan_swapcha
 void vulkan_swapchain_refresh(vulkan_swapchain_t* swapchain, renderer_t* renderer, vulkan_swapchain_create_info_t* create_info)
 {
 	destroy_swapchain(swapchain, renderer);
-	VkSwapchainCreateInfoKHR swapchain_create_info =
-	{
-		.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
-		.surface = renderer->surface,
-		.minImageCount = create_info->image_count,
-		.imageFormat = create_info->image_format,
-		.imageExtent = create_info->image_extent,
-		.imageColorSpace = create_info->image_color_space,
-		.imageArrayLayers = 1,
-		.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-		.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-		.presentMode = create_info->present_mode,
-		.clipped = VK_TRUE,
-		.oldSwapchain = VK_NULL_HANDLE,
-		.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR
-	};
-	swapchain->handle = vk_get_swapchain(renderer->logical_device->handle, &swapchain_create_info);
-	swapchain->image_count = create_info->image_count;
-	vk_get_images_out(renderer->logical_device->handle, swapchain->handle, swapchain->images, swapchain->image_count);
-	vk_get_image_views_out(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images, swapchain->image_views);
-	VkFormat* formats = stack_newv(VkFormat, 3);
-	formats[0] = VK_FORMAT_D32_SFLOAT;
-	formats[1] = VK_FORMAT_D32_SFLOAT_S8_UINT;
-	formats[2] = VK_FORMAT_D24_UNORM_S8_UINT;
-	vulkan_image_create_info_t depth_create_info = 
-	{
-		.type = VK_IMAGE_TYPE_2D,
-		.format = vk_find_supported_format(renderer->physical_device->handle, &formats[0], 3, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT),
-		.width = create_info->image_extent.width,
-		.height = create_info->image_extent.height,
-		.depth = 1,
-		.tiling = VK_IMAGE_TILING_OPTIMAL,
-		.layout = VK_IMAGE_LAYOUT_UNDEFINED,
-		.usage_mask = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
-		.memory_properties_mask = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-		.aspect_mask = VK_IMAGE_ASPECT_DEPTH_BIT
-	};
-	if((depth_create_info.format == VK_FORMAT_D24_UNORM_S8_UINT) || (depth_create_info.format == VK_FORMAT_D32_SFLOAT_S8_UINT))
-		depth_create_info.aspect_mask |= VK_IMAGE_ASPECT_STENCIL_BIT;
-	vulkan_image_create_no_alloc(renderer, &depth_create_info, swapchain->depth_image);
-	swapchain->depth_image_view = vulkan_image_get_image_view(swapchain->depth_image);
-
-	VkImageView* attachments_lists[swapchain->image_count];
-	uint32_t attachments_count[swapchain->image_count];
-	for(uint32_t i = 0; i < swapchain->image_count; i++) 
-	{
-		swapchain->framebuffer_image_views[2 * i + 0] = *(swapchain->image_views + i);
-		swapchain->framebuffer_image_views[2 * i + 1] = swapchain->depth_image_view;
-		attachments_lists[i] = &swapchain->framebuffer_image_views[2 * i];
-		attachments_count[i] = 2;
-	}
-	vk_get_framebuffers_out(	renderer->logical_device->handle, renderer->vk_render_pass, 
-								(VkExtent2D) { renderer->window->width, renderer->window->height }, 
-								1, 
-								&attachments_lists[0], &attachments_count[0], 
-								swapchain->image_count, swapchain->framebuffers);
-	stack_free(formats);
+	create_swapchain(swapchain, renderer, create_info);
 }
 
 void vulkan_swapchain_destroy(vulkan_swapchain_t* swapchain, renderer_t* renderer)
@@ -145,8 +89,16 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 	log_msg("Swapchain image count: %u\n", swapchain->image_count);
 	log_msg("Swapchain image size: (%u, %u)\n", create_info->image_extent.width, create_info->image_extent.height);
 
-	swapchain->images = vk_get_images(renderer->logical_device->handle, swapchain->handle).value2;
-	swapchain->image_views = vk_get_image_views(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images).value2;
+	// if the swapchain has to be recreated then no allocation should happen, use *_out versions instead
+	if(swapchain->images == NULL)
+		swapchain->images = vk_get_images(renderer->logical_device->handle, swapchain->handle).value2;
+	else vk_get_images_out(renderer->logical_device->handle, swapchain->handle, swapchain->images, swapchain->image_count);
+	
+	// if the swapchain has to be recreated then no allocation should happen, use *_out versions instead
+	if(swapchain->image_views == NULL)
+		swapchain->image_views = vk_get_image_views(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images).value2;
+	else vk_get_image_views_out(renderer->logical_device->handle, create_info->image_format, swapchain->image_count, swapchain->images, swapchain->image_views);
+
 	VkFormat* formats = stack_newv(VkFormat, 3);
 	formats[0] = VK_FORMAT_D32_SFLOAT;
 	formats[1] = VK_FORMAT_D32_SFLOAT_S8_UINT;
@@ -166,12 +118,22 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 	};
 	if((depth_create_info.format == VK_FORMAT_D24_UNORM_S8_UINT) || (depth_create_info.format == VK_FORMAT_D32_SFLOAT_S8_UINT))
 		depth_create_info.aspect_mask |= VK_IMAGE_ASPECT_STENCIL_BIT;
-	swapchain->depth_image = vulkan_image_create(renderer, &depth_create_info);
+	
+	// if the swapchain has to be recreated then allocation should happen, use *_no_alloc versions instead
+	if(swapchain->depth_image == NULL)
+		swapchain->depth_image = vulkan_image_create(renderer, &depth_create_info);
+	else 
+		vulkan_image_create_no_alloc(renderer, &depth_create_info, swapchain->depth_image);
+	
 	swapchain->depth_image_view = vulkan_image_get_image_view(swapchain->depth_image);
 
 	VkImageView* attachments_lists[swapchain->image_count];
 	uint32_t attachments_count[swapchain->image_count];
-	swapchain->framebuffer_image_views = heap_newv(VkImageView, 2 * swapchain->image_count);
+
+	// if the swapchain has to be recreated then no allocation should happen	
+	if(swapchain->framebuffer_image_views == NULL)
+		swapchain->framebuffer_image_views = heap_newv(VkImageView, 2 * swapchain->image_count);
+	
 	for(uint32_t i = 0; i < swapchain->image_count; i++) 
 	{
 		swapchain->framebuffer_image_views[2 * i + 0] = *(swapchain->image_views + i);
@@ -179,11 +141,20 @@ static void create_swapchain(vulkan_swapchain_t* swapchain, renderer_t* renderer
 		attachments_lists[i] = &swapchain->framebuffer_image_views[2 * i];
 		attachments_count[i] = 2;
 	}
-	swapchain->framebuffers = vk_get_framebuffers(	renderer->logical_device->handle, renderer->vk_render_pass, 
-													(VkExtent2D) { renderer->window->width, renderer->window->height },
-													1,
-													&attachments_lists[0],
-													&attachments_count[0], swapchain->image_count).value2;
+
+	// if the swapchain has to be recreated then no allocation should happen, use *_out versions instead
+	if(swapchain->framebuffers == NULL)
+		swapchain->framebuffers = vk_get_framebuffers(	renderer->logical_device->handle, renderer->vk_render_pass, 
+														(VkExtent2D) { renderer->window->width, renderer->window->height },
+														1,
+														&attachments_lists[0],
+														&attachments_count[0], swapchain->image_count).value2;
+	else
+		vk_get_framebuffers_out(	renderer->logical_device->handle, renderer->vk_render_pass, 
+									(VkExtent2D) { renderer->window->width, renderer->window->height }, 
+									1, 
+									&attachments_lists[0], &attachments_count[0], 
+									swapchain->image_count, swapchain->framebuffers);
 	swapchain->current_image_index = 0;
 	stack_free(formats);
 }

--- a/source/renderer/vulkan/vulkan_texture.c
+++ b/source/renderer/vulkan/vulkan_texture.c
@@ -6,6 +6,8 @@
 #include <memory_allocator/memory_allocator.h>
 #include <renderer/assert.h>
 
+static VkFormat get_format_from_type(vulkan_texture_type_t type);
+
 vulkan_texture_t* vulkan_texture_new()
 {
 	vulkan_texture_t* texture = heap_new(vulkan_texture_t);
@@ -45,7 +47,7 @@ vulkan_texture_t* vulkan_texture_create(renderer_t* renderer, vulkan_texture_cre
 		.width = texture_width,
 		.height = texture_height,
 		.depth = 1,
-		.format = VK_FORMAT_B8G8R8A8_SRGB,
+		.format = get_format_from_type(create_info->type),
 		.tiling = VK_IMAGE_TILING_OPTIMAL,
 		.layout = VK_IMAGE_LAYOUT_UNDEFINED,
 		.usage_mask = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
@@ -110,4 +112,19 @@ void vulkan_texture_release_resources(vulkan_texture_t* texture)
 	ASSERT_NOT_NULL(texture);
 	vulkan_image_release_resources(texture->image);
 	heap_free(texture);
+}
+
+
+static VkFormat get_format_from_type(vulkan_texture_type_t type)
+{
+	switch(type)
+	{
+		case VULKAN_TEXTURE_TYPE_ALBEDO:
+			return VK_FORMAT_R8G8B8A8_SRGB;
+		case VULKAN_TEXTURE_TYPE_NORMAL:
+			return VK_FORMAT_R8G8B8A8_UNORM;
+		default:
+			log_wrn("Vulkan texture type is invalid, using VK_FORMAT_R8G8B8A8_SRGB format\n");
+			return VK_FORMAT_R8G8B8A8_SRGB;
+	}
 }

--- a/source/renderer/vulkan/vulkan_wrapper.c
+++ b/source/renderer/vulkan/vulkan_wrapper.c
@@ -306,13 +306,41 @@ function_signature(VkPipeline, vk_get_graphics_pipeline, VkDevice device, VkPipe
 	CALLTRACE_RETURN(graphicsPipeline);
 }
 
-function_signature(VkRenderPass, vk_get_render_pass, VkDevice device, VkFormat format)
+function_signature(VkRenderPass, vk_get_render_pass, VkDevice device, VkFormat format, VkFormat depth_format)
 {
 	CALLTRACE_BEGIN();
-	VkAttachmentDescription color_attachment = vk_get_attachment_description(VK_ATTACHMENT_STORE_OP_STORE, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, format);
-	VkAttachmentDescription depth_attachment = vk_get_attachment_description(VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_FORMAT_D32_SFLOAT);
-	VkAttachmentReference color_attachment_reference = vk_get_attachment_reference(0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-	VkAttachmentReference depth_attachment_reference = vk_get_attachment_reference(1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+	VkAttachmentDescription color_attachment = 
+	{
+		.format = format,
+		.samples = VK_SAMPLE_COUNT_1_BIT,
+		.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+		.storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+		.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+		.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+	};
+	VkAttachmentDescription depth_attachment = 
+	{
+		.format = depth_format,
+		.samples = VK_SAMPLE_COUNT_1_BIT,
+		.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+		.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+		.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+		.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+		.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+	};
+	VkAttachmentReference color_attachment_reference =
+	{
+		.attachment = 0,
+		.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+	};
+	VkAttachmentReference depth_attachment_reference = 
+	{
+		.attachment = 1,
+		.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+	};
 	VkSubpassDescription subpass  = vk_get_subpass_description(&color_attachment_reference, 1, &depth_attachment_reference);
 	VkAttachmentDescription attachments[2] = { color_attachment, depth_attachment };
 	VkSubpassDependency dependency = vk_get_subpass_dependency();
@@ -353,30 +381,6 @@ function_signature(VkSubpassDescription, vk_get_subpass_description, VkAttachmen
 	subpass.pColorAttachments = color_attachments;
 	subpass.pDepthStencilAttachment = depth_stencil_attachment;
 	CALLTRACE_RETURN(subpass);
-}
-
-function_signature(VkAttachmentReference, vk_get_attachment_reference, uint32_t index, VkImageLayout layout)
-{
-	CALLTRACE_BEGIN();
-	VkAttachmentReference colorAttachmentRef = {};
-	colorAttachmentRef.attachment = index;
-	colorAttachmentRef.layout = layout;
-	CALLTRACE_RETURN(colorAttachmentRef);
-}
-
-function_signature(VkAttachmentDescription, vk_get_attachment_description, VkAttachmentStoreOp store_op, VkImageLayout final_layout, VkFormat image_format)
-{
-	CALLTRACE_BEGIN();
-	VkAttachmentDescription colorAttachment = {};
-    colorAttachment.format = image_format;
-    colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-    colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	colorAttachment.storeOp = store_op;
-	colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	colorAttachment.finalLayout = final_layout;
-	CALLTRACE_RETURN(colorAttachment);
 }
 
 function_signature(VkPipelineLayout, vk_get_pipeline_layout, VkDevice device, uint32_t set_layout_count, VkDescriptorSetLayout* set_layouts, uint32_t push_constant_range_count, VkPushConstantRange* push_constant_ranges)

--- a/testbed/source/main.c
+++ b/testbed/source/main.c
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
 	mesh3d_make_centroid_origin(box_mesh3d);
 	mesh3d_calculate_tangents(box_mesh3d);
 	mesh_t* box = mesh_create(renderer, box_mesh3d);
-	shader_t* box_shader = shader_load(renderer, "resource/shaders/bump_shader.sb");
+	shader_t* box_shader = shader_load(renderer, "resource/shaders/specular_bump_shader.sb");
 	per_vertex_attributes[0] = MATERIAL_ALIGN(MATERIAL_VEC3, 0); // position
 	per_vertex_attributes[1] = MATERIAL_ALIGN(MATERIAL_VEC3, 1); // normal
 	per_vertex_attributes[2] = MATERIAL_ALIGN(MATERIAL_VEC2, 2); // texture coordinates
@@ -129,8 +129,8 @@ int main(int argc, char** argv)
 	material_t* box_material = material_create(renderer, &box_material_info);
 	texture_t* box_textures[] = 
 	{ 
-		texture_load(renderer, "resource/textures/white.bmp"),
-		texture_load(renderer, "resource/textures/normal_map.bmp")
+		texture_load(renderer, "resource/textures/white.bmp", TEXTURE_TYPE_ALBEDO),
+		texture_load(renderer, "resource/textures/normal_map.bmp", TEXTURE_TYPE_NORMAL)
 	};
 	material_set_texture2d(box_material, "albedo", box_textures[0]);
 	material_set_texture2d(box_material, "normal_map", box_textures[1]);
@@ -140,10 +140,10 @@ int main(int argc, char** argv)
 	mesh3d_t* cube_mesh3d = mesh3d_cube(1);
 	// mesh3d_calculate_tangents(cube_mesh3d);
 	mesh_t* cube = mesh_create(renderer, cube_mesh3d);
-	texture_t* linux_texture = texture_load(renderer, "resource/textures/linuxlogo.bmp");
-	texture_t* windows_texture = texture_load(renderer, "resource/textures/windowslogo.bmp");
-	texture_t* apple_texture = texture_load(renderer, "resource/textures/applelogo.bmp");
-	texture_t* normal_map_texture = texture_load(renderer, "resource/textures/normal_map.bmp");
+	texture_t* linux_texture = texture_load(renderer, "resource/textures/linuxlogo.bmp", TEXTURE_TYPE_ALBEDO);
+	texture_t* windows_texture = texture_load(renderer, "resource/textures/windowslogo.bmp", TEXTURE_TYPE_ALBEDO);
+	texture_t* apple_texture = texture_load(renderer, "resource/textures/applelogo.bmp", TEXTURE_TYPE_ALBEDO);
+	texture_t* normal_map_texture = texture_load(renderer, "resource/textures/normal_map.bmp", TEXTURE_TYPE_ALBEDO);
 
 	shader_t* albedo_shader = shader_load(renderer, "resource/shaders/albedo_shader.sb");
 	per_vertex_attributes[0] = MATERIAL_ALIGN(MATERIAL_VEC3, 0); //position
@@ -202,6 +202,12 @@ int main(int argc, char** argv)
 		material_set_vec3(box_material, "light.dir", vec3_normalize(float)(vec3(float)(1, -1, 0)));
 		material_set_float(box_material, "light.intensity", 1.0f);
 
+		vec4_t(float) eye_dir = mat4_mul_vec4(float)(camera_transform, 1, 0, 0, 0);
+		material_set_vec3(box_material, "misc.eye_dir", vec3_normalize(float)(vec3(float)(eye_dir.x, eye_dir.y, eye_dir.z)));
+
+		material_set_vec3(box_material, "properties.specular_color", vec3(float)(1, 1, 1));
+		material_set_float(box_material, "properties.specularity", 2);
+
 		renderer_begin_frame(renderer, 0, 0, 0, 0);
 
 		material_bind(box_material, renderer);
@@ -220,24 +226,24 @@ int main(int argc, char** argv)
 		// material_set_push_mat4(cube_material, "push.model_matrix", model_matrix);
 		// mesh_draw_indexed(cube, renderer);
 
-		material_bind(quad_material, renderer);
-		mat4_move(float)(&model_matrix, mat4_mul(float)(2, mat4_translation(float)(-0.8f, 0, 0), mat4_rotation(float)(0, 0, 80 * DEG2RAD)));
-		mat4_move(float)(&mvp, mat4_mul(float)(4, clip_matrix, projection_matrix, view_matrix, model_matrix));
-		mat4_move(float)(&mvp, mat4_transpose(float)(mvp));
-		material_set_push_mat4(quad_material, "push.mvp_matrix", mvp);
-		mesh_draw_indexed(quad, renderer);
+		// material_bind(quad_material, renderer);
+		// mat4_move(float)(&model_matrix, mat4_mul(float)(2, mat4_translation(float)(-0.8f, 0, 0), mat4_rotation(float)(0, 0, 80 * DEG2RAD)));
+		// mat4_move(float)(&mvp, mat4_mul(float)(4, clip_matrix, projection_matrix, view_matrix, model_matrix));
+		// mat4_move(float)(&mvp, mat4_transpose(float)(mvp));
+		// material_set_push_mat4(quad_material, "push.mvp_matrix", mvp);
+		// mesh_draw_indexed(quad, renderer);
 
-		material_bind(text_material, renderer);
-		mat4_t(float) canvas_transform = mat4_mul(float)(2, clip_matrix, screen_space_matrix);
-		mat4_t(float) _model_matrix = mat4_mul(float)(2, mat4_translation(float)(0, 0, 0), mat4_scale(float)(0, 50, 50));
-		material_set_push_mat4(text_material, "push.mvp_matrix", mat4_transpose(float)(mat4_mul(float)(2, canvas_transform, _model_matrix)));
-		text_mesh_draw(text_mesh);
+		// material_bind(text_material, renderer);
+		// mat4_t(float) canvas_transform = mat4_mul(float)(2, clip_matrix, screen_space_matrix);
+		// mat4_t(float) _model_matrix = mat4_mul(float)(2, mat4_translation(float)(0, 0, 0), mat4_scale(float)(0, 50, 50));
+		// material_set_push_mat4(text_material, "push.mvp_matrix", mat4_transpose(float)(mat4_mul(float)(2, canvas_transform, _model_matrix)));
+		// text_mesh_draw(text_mesh);
 
 
-		material_bind(game_ui_material, renderer);
-		mat4_move(float)(&_model_matrix, mat4_mul(float)(2, mat4_scale(float)(50, 50, 50), mat4_identity(float)()));
-		material_set_push_mat4(game_ui_material, "push.mvp_matrix", mat4_transpose(float)(mat4_mul(float)(2, canvas_transform, _model_matrix)));
-		text_mesh_draw(game_ui);
+		// material_bind(game_ui_material, renderer);
+		// mat4_move(float)(&_model_matrix, mat4_mul(float)(2, mat4_scale(float)(50, 50, 50), mat4_identity(float)()));
+		// material_set_push_mat4(game_ui_material, "push.mvp_matrix", mat4_transpose(float)(mat4_mul(float)(2, canvas_transform, _model_matrix)));
+		// text_mesh_draw(game_ui);
 		// mesh_draw_indexed(glyph_A, renderer);
 		// mesh_draw_indexed(glyph_B, renderer);
 


### PR DESCRIPTION
Bug fixes:
1. The texture format for normal texture was incorrect (sRGB), so just changed it to unsigned normalized (UNORM).
2. Semaphore validation error when setting the larger resolution of the window.

Refactor:
1. Refactored swapchain (duplicated code in swapchain_refresh and swapchain_create)

New feature:
TEXTURE_TYPE_ALBEDO, TEXTURE_TYPE_NORMAL