### PR TITLE
Added vulkan_render_pass_instance.h/.c and fixed some incorrect values

### DIFF
--- a/include/renderer/internal/vulkan/vulkan_render_pass.h
+++ b/include/renderer/internal/vulkan/vulkan_render_pass.h
@@ -93,6 +93,9 @@ typedef struct vulkan_render_pass_t
 
 	vulkan_render_pass_handle_t handle;
 
+	/* number of instances of this render pass (call to vulkan_render_pass_instance_create_* increments it */
+	u32 instance_count;
+
 	/* vulkan object handle */
 	VkRenderPass vo_handle;
 
@@ -136,10 +139,6 @@ typedef struct vulkan_render_pass_t
 
 	/* render set layout for this render pass */
 	vulkan_descriptor_set_layout_t render_set_layout;
-
-	/* render set for this render pass */
-	vulkan_descriptor_set_t render_set;
-
 
 	/* formats of each attachment [only for internal use] */
 	VkFormat* vo_formats;

--- a/include/renderer/internal/vulkan/vulkan_render_pass_instance.h
+++ b/include/renderer/internal/vulkan/vulkan_render_pass_instance.h
@@ -3,12 +3,22 @@
 
 #include <renderer/defines.h>
 #include <renderer/internal/vulkan/vulkan_render_pass.h>
-#include <renderer/internal/vulkan/vulkan_descriptor_set.h>
+
+/* structure to store create information for vulkan_render_pass_instance_t object */
+typedef struct vulkan_render_pass_instance_create_info_t
+{
+	/* handle to the vulkan render pass object in the vulkan render pass pool */
+	vulkan_render_pass_handle_t render_pass_handle;
+} vulkan_render_pass_instance_create_info_t;
 
 typedef struct vulkan_render_pass_instance_t
 {
-	vulkan_render_pass_t* render_pass;			// ptr to the actual render pass
-	vulkan_descriptor_set_t** set;				// render set for each sub pass
+	/* pointer to the vulkan api context */
+	vulkan_renderer_t* renderer;
+	/* pointer to the render pass (vulkan_render_pass_t) to which this instance refers */
+	vulkan_render_pass_t* render_pass;
+	/* pointer to the render set (vulkan_descriptor_set_t); it is unique for every render pass instance */
+	vulkan_descriptor_set_t render_set;
 } vulkan_render_pass_instance_t;
 
 
@@ -16,15 +26,19 @@ BEGIN_CPP_COMPATIBLE
 
 /* constructors & destructors */
 RENDERER_API vulkan_render_pass_instance_t* vulkan_render_pass_instance_new(memory_allocator_t* allocator);
-RENDERER_API vulkan_render_pass_instance_t* vulkan_render_pass_instance_create(vulkan_render_pass_t* pass);
+RENDERER_API vulkan_render_pass_instance_t* vulkan_render_pass_instance_create(vulkan_renderer_t* renderer, vulkan_render_pass_instance_create_info_t* create_info);
+RENDERER_API void vulkan_render_pass_instance_create_no_alloc(vulkan_renderer_t* renderer, vulkan_render_pass_instance_create_info_t* create_info, vulkan_render_pass_instance_t OUT render_pass);
 RENDERER_API void vulkan_render_pass_instance_destroy(vulkan_render_pass_instance_t* instance);
-RENDERER_API void vulkan_render_pass_release_resources(vulkan_render_pass_instance_t* instance);
+RENDERER_API void vulkan_render_pass_instance_release_resources(vulkan_render_pass_instance_t* instance);
 
-
-RENDERER_API void vulkan_render_pass_instance_begin(vulkan_render_pass_instance_t* instance);
+RENDERER_API void vulkan_render_pass_instance_set_clear_indirect(vulkan_render_pass_instance_t* instance, color_t color, float depth, VkClearValue* indirect_buffer);
+RENDERER_API void vulkan_render_pass_instance_set_clear(vulkan_render_pass_instance_t* instance, color_t color, float depth);
+RENDERER_API void vulkan_render_pass_instance_begin(vulkan_render_pass_instance_t* instance, u32 framebuffer_index, vulkan_camera_t* camera);
 RENDERER_API void vulkan_render_pass_instance_end(vulkan_render_pass_instance_t* instance);
 RENDERER_API void vulkan_render_pass_instance_next(vulkan_render_pass_instance_t* instance);
-RENDERER_API u32 vulkan_render_pass_instance_get_sub_pass_count(vulkan_render_pass_instance_t* instance);
-RENDERER_API void vulkan_render_pass_instance_bind_set(vulkan_render_pass_instance_t* instance, u32 sub_pass_index);
+
+typedef vulkan_render_pass_refresh_info_t vulkan_render_pass_instance_refresh_info_t;
+
+RENDERER_API void vulkan_render_pass_instance_refresh(vulkan_render_pass_instance_t* instance, vulkan_render_pass_instance_refresh_info_t* info);
 
 END_CPP_COMPATIBLE

--- a/include/renderer/internal/vulkan/vulkan_shader.h
+++ b/include/renderer/internal/vulkan/vulkan_shader.h
@@ -5,6 +5,7 @@
 #include <renderer/internal/vulkan/vulkan_descriptor_set_layout.h> // vulkan_descriptor_set_layout_t
 #include <renderer/internal/vulkan/vulkan_attachment.h> 		// vulkan_attachment_type_t
 #include <renderer/internal/vulkan/vulkan_handles.h> 		// vulkan_render_pass_handle_t, vulkan_shader_handle_t
+#include <renderer/internal/vulkan/vulkan_render_pass_instance.h>
 #include <renderer/event.h>
 #include <glslcommon/glsl_types.h>
 #define VERTEX_ATTRIB(value, index) ((value) << ((index) * 5))
@@ -106,8 +107,8 @@ typedef struct vulkan_shader_subpass_t
 
 typedef struct vulkan_shader_render_pass_t
 {
-	/* handle to the render pass instance into the render pass pool */
-	vulkan_render_pass_handle_t handle;
+	/* pointer to the render pass instance object */
+	vulkan_render_pass_instance_t instance;
 	/* deep copy of render set bindings passed with the render pass description 
 	 * dimensions: [render_set_binding_count] */
 	vulkan_shader_resource_description_t* render_set_bindings;
@@ -199,5 +200,6 @@ RENDERER_API void vulkan_shader_release_resources(vulkan_shader_t* shader);
 /* logic functions */
 RENDERER_API vulkan_graphics_pipeline_t* vulkan_shader_get_pipeline(vulkan_shader_t* shader, vulkan_render_pass_handle_t handle, u32 subpass_index);
 RENDERER_API vulkan_pipeline_layout_t* vulkan_shader_get_pipeline_layout(vulkan_shader_t* shader, vulkan_render_pass_handle_t handle, u32 subpass_index);
+RENDERER_API vulkan_render_pass_instance_t* vulkan_shader_get_render_pass_instance(vulkan_shader_t* shader, vulkan_render_pass_handle_t handle);
 
 END_CPP_COMPATIBLE

--- a/source/renderer/vulkan/vulkan_render_pass.c
+++ b/source/renderer/vulkan/vulkan_render_pass.c
@@ -75,6 +75,7 @@ RENDERER_API void vulkan_render_pass_create_no_alloc(vulkan_renderer_t* renderer
 	memzero(render_pass, vulkan_render_pass_t);
 
 	render_pass->renderer = renderer;
+	render_pass->instance_count = 0;
 	render_pass->subpass_count = create_info->subpass_count;
 	render_pass->current_subpass_index = 0;
 	render_pass->handle = VULKAN_RENDER_PASS_HANDLE_INVALID;
@@ -160,7 +161,6 @@ RENDERER_API void vulkan_render_pass_create_no_alloc(vulkan_renderer_t* renderer
 		.vo_pool = renderer->vo_descriptor_pool,
 		.layout = &render_pass->render_set_layout
 	};
-	vulkan_descriptor_set_create_no_alloc(renderer, &set_create_info, &render_pass->render_set);
 
 	// create sub render set layouts & subb render sets
 	render_pass->sub_render_set_layouts = memory_allocator_alloc_obj_array(renderer->allocator, MEMORY_ALLOCATION_TYPE_OBJ_VK_DESCRIPTOR_SET_LAYOUT_ARRAY, vulkan_descriptor_set_layout_t, create_info->subpass_count);
@@ -214,7 +214,6 @@ RENDERER_API void vulkan_render_pass_destroy(vulkan_render_pass_t* render_pass)
 	}
 
 	// destroy the vulkan descriptor sets and layouts (render set and layout)
-	vulkan_descriptor_set_destroy(&render_pass->render_set);
 	vulkan_descriptor_set_layout_destroy(&render_pass->render_set_layout);
 }
 

--- a/source/renderer/vulkan/vulkan_render_pass_instance.c
+++ b/source/renderer/vulkan/vulkan_render_pass_instance.c
@@ -1,0 +1,75 @@
+#include <renderer/internal/vulkan/vulkan_render_pass_instance.h>
+#include <renderer/internal/vulkan/vulkan_renderer.h>
+#include <renderer/internal/vulkan/vulkan_render_pass_pool.h>
+#include <renderer/memory_allocator.h>
+
+RENDERER_API vulkan_render_pass_instance_t* vulkan_render_pass_instance_new(memory_allocator_t* allocator)
+{
+	vulkan_render_pass_instance_t* instance = memory_allocator_alloc_obj(allocator, MEMORY_ALLOCATION_TYPE_OBJ_VK_RENDER_PASS_INSTANCE, vulkan_render_pass_instance_t);
+	memzero(instance, vulkan_render_pass_instance_t);
+	return instance;
+}
+
+RENDERER_API vulkan_render_pass_instance_t* vulkan_render_pass_instance_create(vulkan_renderer_t* renderer, vulkan_render_pass_instance_create_info_t* create_info)
+{
+	vulkan_render_pass_instance_t* instance = vulkan_render_pass_instance_new(renderer->allocator);
+	vulkan_render_pass_instance_create_no_alloc(renderer, create_info, instance);
+	return instance;
+}
+
+RENDERER_API void vulkan_render_pass_instance_create_no_alloc(vulkan_renderer_t* renderer, vulkan_render_pass_instance_create_info_t* create_info, vulkan_render_pass_instance_t OUT instance)
+{
+	memzero(instance, vulkan_render_pass_instance_t);
+	instance->renderer = renderer;
+	instance->render_pass = vulkan_render_pass_pool_getH(renderer->render_pass_pool, create_info->render_pass_handle);
+	vulkan_descriptor_set_create_info_t set_create_info = 
+	{
+		.vo_pool = renderer->vo_descriptor_pool,
+		.layout = &instance->render_pass->render_set_layout
+	};
+	vulkan_descriptor_set_create_no_alloc(renderer, &set_create_info, &instance->render_set);
+	instance->render_pass->instance_count++;
+}
+
+RENDERER_API void vulkan_render_pass_instance_destroy(vulkan_render_pass_instance_t* instance)
+{
+	vulkan_descriptor_set_destroy(&instance->render_set);
+	_debug_assert__(instance->render_pass->instance_count > 0);
+	instance->render_pass->instance_count--;
+}
+
+RENDERER_API void vulkan_render_pass_instance_release_resources(vulkan_render_pass_instance_t* instance)
+{
+
+}
+
+
+RENDERER_API void vulkan_render_pass_instance_set_clear_indirect(vulkan_render_pass_instance_t* instance, color_t color, float depth, VkClearValue* indirect_buffer)
+{
+	vulkan_render_pass_set_clear_indirect(instance->render_pass, color, depth, indirect_buffer);
+}
+
+RENDERER_API void vulkan_render_pass_instance_set_clear(vulkan_render_pass_instance_t* instance, color_t color, float depth)
+{
+	vulkan_render_pass_set_clear(instance->render_pass, color, depth);
+}
+
+RENDERER_API void vulkan_render_pass_instance_begin(vulkan_render_pass_instance_t* instance, u32 framebuffer_index, vulkan_camera_t* camera)
+{
+	vulkan_render_pass_begin(instance->render_pass, framebuffer_index, camera);
+}
+
+RENDERER_API void vulkan_render_pass_instance_end(vulkan_render_pass_instance_t* instance)
+{
+	vulkan_render_pass_end(instance->render_pass);
+}
+
+RENDERER_API void vulkan_render_pass_instance_next(vulkan_render_pass_instance_t* instance)
+{
+	vulkan_render_pass_next(instance->render_pass);
+}
+
+RENDERER_API void vulkan_render_pass_instance_refresh(vulkan_render_pass_instance_t* instance, vulkan_render_pass_instance_refresh_info_t* info)
+{
+	vulkan_render_pass_refresh(instance->render_pass, info);
+}

--- a/source/renderer/vulkan/vulkan_render_queue.c
+++ b/source/renderer/vulkan/vulkan_render_queue.c
@@ -161,16 +161,16 @@ RENDERER_API vulkan_render_object_handle_t vulkan_render_queue_add(vulkan_render
 	for(u32 i = 0; i < pass_count; i++)
 	{
 		subpass_shader_list_t* lists;
-		u32 subpass_count = passes[i].subpass_count;
-		if(!dictionary_contains(&queue->render_pass_handles, &passes[i].handle))
+		u32 subpass_count = passes[i].instance.render_pass->subpass_count;
+		if(!dictionary_contains(&queue->render_pass_handles, &passes[i].instance.render_pass->handle))
 		{
 			lists = memory_allocator_alloc_obj_array(queue->renderer->allocator, MEMORY_ALLOCATION_TYPE_OBJ_SUBPASS_SHADER_LIST_ARRAY, subpass_shader_list_t, subpass_count);
 			for(u32 j = 0; j < subpass_count; j++)
 				lists[j] = buf_create(sizeof(vulkan_shader_handle_t), 1, 0);
-			dictionary_add(&queue->render_pass_handles, &passes[i].handle, &lists);
+			dictionary_add(&queue->render_pass_handles, &passes[i].instance.render_pass->handle, &lists);
 		}
 		else
-			lists = DEREF_TO(subpass_shader_list_t*, dictionary_get_value_ptr(&queue->render_pass_handles, &passes[i].handle));
+			lists = DEREF_TO(subpass_shader_list_t*, dictionary_get_value_ptr(&queue->render_pass_handles, &passes[i].instance.render_pass->handle));
 		for(u32 j = 0; j < subpass_count; j++)
 		{
 			if(buf_find_index_of(&lists[j], &obj->material->shader->handle, buf_u64_comparer) == BUF_INVALID_INDEX)
@@ -259,7 +259,7 @@ RENDERER_API void vulkan_render_queue_dispatch(vulkan_render_queue_t* queue, vul
 				// bind GLOBAL_SET
 				vulkan_descriptor_set_bind(&queue->renderer->global_set, VULKAN_DESCRIPTOR_SET_GLOBAL, pipeline_layout); 
 				// bind RENDER_SET
-				vulkan_descriptor_set_bind(&pass->render_set, VULKAN_DESCRIPTOR_SET_RENDER, pipeline_layout);
+				vulkan_descriptor_set_bind(&vulkan_shader_get_render_pass_instance(shader, pass_handle)->render_set, VULKAN_DESCRIPTOR_SET_RENDER, pipeline_layout);
 				// bind SUB_RENDER_SET
 				vulkan_descriptor_set_bind(&pass->sub_render_sets[j], VULKAN_DESCRIPTOR_SET_SUB_RENDER, pipeline_layout);
 

--- a/source/test.c
+++ b/source/test.c
@@ -97,7 +97,7 @@ RENDERER_API test_t* test_create(memory_allocator_t* allocator, const char* name
 					"\tTID_43_CASE_1\n"	
 					"\tTID_43_CASE_2\n"	
 					"\tTID_43_CASE_3\n"	
-					"\tTID_43_CASE_4\n"	
+					"\tTID_43_CASE_4\n"
 				);
 		exit(0);
 	}


### PR DESCRIPTION
Implemented an instanced version of vulkan render pass as the render set (descriptor set) must be unique to every owner (shader) of the render pass pointer.