### PR TITLE
TID-31/UnitTest - text mesh font rendering

### DIFF
--- a/include/renderer/internal/vulkan/vulkan_shader_resource_description.h
+++ b/include/renderer/internal/vulkan/vulkan_shader_resource_description.h
@@ -35,14 +35,10 @@ typedef struct vulkan_shader_resource_description_t
 {
 	struct_descriptor_t handle;
 	bool is_push_constant;						// is this a push constant ?
-	union
+	struct
 	{
-		struct
-		{
-			bool is_per_vertex_attribute; 		// does this represents per vertex attribute ?
-			bool is_per_instance_attribute; 	// does this represents per instance attribute ?
-		};
-		u16 is_attribute;						// is this an attribute ?
+		bool is_per_vertex_attribute; 		// does this represents per vertex attribute ?
+		bool is_per_instance_attribute; 	// does this represents per instance attribute ?
 	};
 	bool is_opaque;								// is this an opaque handle to a resource ?
 	bool is_uniform;							// is this an uniform resource ?
@@ -81,4 +77,9 @@ static INLINE_IF_RELEASE_MODE struct_descriptor_t* begin_uniform(vulkan_renderer
 static INLINE_IF_RELEASE_MODE void end_uniform(vulkan_renderer_t* renderer, BUFFER* list)
 {
 	vulkan_shader_resource_description_end_uniform(renderer, buf_peek_ptr(list));
+}
+
+static INLINE_IF_RELEASE_MODE bool vulkan_shader_resource_description_is_attribute(vulkan_shader_resource_description_t* description)
+{
+	return description->is_per_vertex_attribute || description->is_per_instance_attribute;
 }

--- a/include/renderer/internal/vulkan/vulkan_vertex_buffer_layout_description.h
+++ b/include/renderer/internal/vulkan/vulkan_vertex_buffer_layout_description.h
@@ -328,8 +328,8 @@ typedef struct vulkan_vertex_buffer_layout_description_t
 	u32 input_rate;
 	u32 size;
 	u32 attribute_count;
-	u16 binding;
-	u16* attribute_locations;
+	u32 binding;
+	u32* attribute_locations;
 	VkFormat* attribute_formats;
 	u32* attribute_offsets;
 } vulkan_vertex_buffer_layout_description_t;

--- a/include/renderer/mesh3d.h
+++ b/include/renderer/mesh3d.h
@@ -56,6 +56,12 @@
 
 #define MESH3D_MAX_ATTRIBUTE_COUNT 5
 #define MESH3D_INDEX_SIZE 4 //sizeof(u32)
+#define MESH3D_VERTEX_ATTRIB_POSITION_SIZE sizeof(vec4_t)
+#define MESH3D_VERTEX_ATTRIB_NORMAL_SIZE sizeof(vec4_t)
+#define MESH3D_VERTEX_ATTRIB_COLOR_SIZE sizeof(vec4_t)
+#define MESH3D_VERTEX_ATTRIB_UV_SIZE sizeof(vec2_t)
+#define MESH3D_VERTEX_ATTRIB_TANGENT_SIZE sizeof(vec4_t)
+#define MESH3D_VERTEX_ATTRIB_TRIANGLE_SIZE sizeof(vec3uint_t)
 
 typedef u32 index_t;
 

--- a/include/renderer/tests/text_mesh.h
+++ b/include/renderer/tests/text_mesh.h
@@ -1,0 +1,36 @@
+/*
+	***This is computer generated notice - Do not modify it***
+
+	VulkanRenderer (inclusive of its dependencies and subprojects 
+	such as toolchains written by the same author) is a software to render 
+	2D & 3D geometries by writing C/C++ code and shaders.
+
+	File: TID-48.case5.h is a part of VulkanRenderer
+
+	Copyright (C) 2023  Author: Ravi Prakash Singh
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+
+#pragma once
+
+
+#include <renderer/test.h>
+
+BEGIN_CPP_COMPATIBLE
+
+TEST_DECLARE(TEXT_MESH);
+
+END_CPP_COMPATIBLE

--- a/include/renderer/tests/text_mesh.h
+++ b/include/renderer/tests/text_mesh.h
@@ -5,7 +5,7 @@
 	such as toolchains written by the same author) is a software to render 
 	2D & 3D geometries by writing C/C++ code and shaders.
 
-	File: TID-48.case5.h is a part of VulkanRenderer
+	File: text_mesh.h is a part of VulkanRenderer
 
 	Copyright (C) 2023  Author: Ravi Prakash Singh
 

--- a/shaders/builtins/text_shader.v3dshader
+++ b/shaders/builtins/text_shader.v3dshader
@@ -1,0 +1,110 @@
+
+#sb version 2022
+#sl version 2022
+
+Shader
+{
+    [NoParse]
+    Properties
+    {
+        vertex [MATERIAL_SET, MATERIAL_PROPERTIES_BINDING] uniform Parameters
+        {
+            int isScreenSpace;
+        } parameters;
+    }
+    [NoParse]
+    Layout
+    {
+        per_vertex [POSITION_BINDING, POSITION_LOCATION] vec3 local_position;
+        per_instance [1, 1] vec3 offset;
+        per_instance [1, 2] vec3 scale;
+        per_instance [1, 3] vec3 rotation;
+    }
+    
+    RenderPass
+    {
+        SubPass
+        {
+            [NoParse]
+            GraphicsPipeline
+            {
+                colorBlend
+                {
+                    attachment { }
+                }
+
+                depthStencil
+                {
+                    depthWriteEnable = false,
+                    depthTestEnable = false
+                }
+            }
+            [NoParse]
+            GLSL
+            {
+                #stage vertex
+        
+                #version 450
+
+                #include <v3d.h>
+                
+                layout(set = CAMERA_SET, binding = CAMERA_PROPERTIES_BINDING) uniform CameraInfo cameraInfo;
+                layout(set = OBJECT_SET, binding = TRANSFORM_BINDING) uniform ObjectInfo objectInfo;
+                layout(set = MATERIAL_SET, binding = MATERIAL_PROPERTIES_BINDING) uniform Parameters
+                {
+                    int isScreenSpace;
+                } parameters;
+
+                //Inputs
+                //per vertex
+                layout(location = POSITION_LOCATION) in vec3 local_position;
+                
+                //per instance
+                layout(location = 1) in vec3 offset;
+                layout(location = 2) in vec3 scale;
+                layout(location = 3) in vec3 rotation;
+
+                mat4 mat4_diagonal(float x, float y, float z, float w)
+                {
+                    mat4 m = mat4(vec4(0, 0, 0, 0), vec4(0, 0, 0, 0), vec4(0, 0, 0, 0), vec4(0, 0, 0, 0));
+                    m[0][0] = x;
+                    m[1][1] = y;
+                    m[2][2] = z;
+                    m[3][3] = w;
+                    return m;
+                }
+                
+                void main()
+                {
+                    vec3 pos = local_position + offset;//offset + local_position * scale;
+                    vec4 clipPos; 
+                    if(parameters.isScreenSpace == 1)
+                    {
+                        mat4 scale = mat4_diagonal(100, 100, 100, 1);
+                        clipPos = cameraInfo.screen * scale * objectInfo.transform * vec4(pos, 1);
+                    }
+                    else if(parameters.isScreenSpace == 0)
+                    {
+                        mat4 scale = mat4_diagonal(0.3, 0.3, 0.3, 1);
+                        clipPos = cameraInfo.projection * cameraInfo.view * scale * objectInfo.transform * vec4(pos, 1);
+                    }
+                    clipPos.y = -clipPos.y;
+                    gl_Position = clipPos;
+                }
+                
+                
+                #stage fragment
+                
+                #version 450
+                
+                layout(location = 0) out vec3 color;
+                
+                void main()
+                {
+                    color = vec3(1, 1, 1);
+                }
+            }
+        }
+    }
+
+}

--- a/shaders/builtins/text_shader.v3dshader
+++ b/shaders/builtins/text_shader.v3dshader
@@ -1,3 +1,28 @@
+/*
+	***This is computer generated notice - Do not modify it***
+
+	VulkanRenderer (inclusive of its dependencies and subprojects 
+	such as toolchains written by the same author) is a software to render 
+	2D & 3D geometries by writing C/C++ code and shaders.
+
+	File: text_shader.v3dshader is a part of VulkanRenderer
+
+	Copyright (C) 2023  Author: Ravi Prakash Singh
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
 
 #sb version 2022
 #sl version 2022

--- a/source/renderer/mesh3d.c
+++ b/source/renderer/mesh3d.c
@@ -87,7 +87,7 @@ RENDERER_API function_signature(void, mesh3d_positions_new, mesh3d_t* mesh, inde
 		buf_free(mesh->positions);
 		mesh->positions = NULL;
 	}
-	mesh->positions = BUFcreate(NULL, sizeof(vec3_t), count, 0);
+	mesh->positions = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_POSITION_SIZE /* sizeof(vec4_t) */, count, 0);
 	debug_assert__(mesh->positions != NULL, "mesh->positions == NULL\n");
 	CALLTRACE_END();
 }
@@ -100,7 +100,7 @@ RENDERER_API function_signature(void, mesh3d_normals_new, mesh3d_t* mesh, index_
 		buf_free(mesh->normals);
 		mesh->normals = NULL;
 	}
-	mesh->normals = BUFcreate(NULL, sizeof(vec3_t), count, 0);
+	mesh->normals = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_NORMAL_SIZE /* sizeof(vec4_t) */, count, 0);
 	CALLTRACE_END();
 }
 
@@ -112,7 +112,7 @@ RENDERER_API function_signature(void, mesh3d_tangents_new, mesh3d_t* mesh, index
 		buf_free(mesh->tangents);
 		mesh->tangents = NULL;
 	}
-	mesh->tangents = BUFcreate(NULL, sizeof(vec3_t), count, 0);
+	mesh->tangents = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_TANGENT_SIZE /* sizeof(vec4_t) */, count, 0);
 	CALLTRACE_END();
 }
 
@@ -124,7 +124,7 @@ RENDERER_API function_signature(void, mesh3d_colors_new, mesh3d_t* mesh, index_t
 		buf_free(mesh->colors);
 		mesh->colors = NULL;
 	}
-	mesh->colors = BUFcreate(NULL, sizeof(vec3_t), count, 0);
+	mesh->colors = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_COLOR_SIZE /* sizeof(vec4_t) */, count, 0);
 	CALLTRACE_END();
 }
 
@@ -137,7 +137,7 @@ RENDERER_API function_signature(void, mesh3d_triangles_new, mesh3d_t* mesh, inde
 		buf_free(mesh->triangles);
 		mesh->triangles = NULL;
 	}
-	mesh->triangles = BUFcreate(NULL, sizeof(vec3uint_t), count, 0);
+	mesh->triangles = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_TRIANGLE_SIZE /* sizeof(vec3uint_t) */, count, 0);
 	CALLTRACE_END();
 }
 
@@ -149,7 +149,7 @@ RENDERER_API function_signature(void, mesh3d_uvs_new, mesh3d_t* mesh, index_t co
 		buf_free(mesh->uvs);
 		mesh->uvs = NULL;
 	}
-	mesh->uvs = BUFcreate(NULL, sizeof(vec2_t), count, 0);
+	mesh->uvs = BUFcreate(NULL, MESH3D_VERTEX_ATTRIB_UV_SIZE /* sizeof(vec2_t) */, count, 0);
 	CALLTRACE_END();
 }
 
@@ -431,7 +431,7 @@ RENDERER_API function_signature(void, mesh3d_position_add, mesh3d_t* mesh, float
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->positions, __POSITIONS_ARE_NOT_FOUND__);
-	vec3_t v = {x, y, z};
+	vec4_t v = { x, y, z, 0 };
 	buf_push(mesh->positions, &v);
 	CALLTRACE_END();
 }
@@ -440,7 +440,8 @@ RENDERER_API function_signature(void, mesh3d_position_add_vec3, mesh3d_t* mesh, 
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->positions, __POSITIONS_ARE_NOT_FOUND__);
-	buf_push(mesh->positions, (void*)(&v));
+	vec4_t v4 = { v.x, v.y, v.z, 0 };
+	buf_push(mesh->positions, &v4);
 	CALLTRACE_END();
 }
 
@@ -457,7 +458,8 @@ RENDERER_API function_signature(void, mesh3d_position_set_vec3, mesh3d_t* mesh, 
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->positions, __POSITIONS_ARE_NOT_FOUND__);
-	buf_set_at(mesh->positions, index, (void*)(&position));
+	vec4_t v4 = { position.x, position.y, position.z, 0 };
+	buf_set_at(mesh->positions, index, &v4);
 	CALLTRACE_END();
 }
 
@@ -524,7 +526,7 @@ RENDERER_API function_signature(void, mesh3d_normal_add, mesh3d_t* mesh, float x
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->normals, __NORMALS_ARE_NOT_FOUND__);
-	vec3_t n = {x, y, z};
+	vec4_t n = { x, y, z, 0 };
 	buf_push(mesh->normals, &n);
 	CALLTRACE_END();
 }
@@ -533,7 +535,8 @@ RENDERER_API function_signature(void, mesh3d_normal_add_vec3, mesh3d_t* mesh, ve
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->normals, __NORMALS_ARE_NOT_FOUND__);
-	buf_push(mesh->normals, (void*)(&v));
+	vec4_t v4 = { v.x, v.y, v.z, 0 };
+	buf_push(mesh->normals, &v4);
 	CALLTRACE_END();
 }
 
@@ -550,7 +553,8 @@ RENDERER_API function_signature(void, mesh3d_normal_set_vec3, mesh3d_t* mesh, in
 {
 	CALLTRACE_BEGIN();
  	debug_assert__(NULL != mesh->normals, __NORMALS_ARE_NOT_FOUND__);
- 	buf_set_at(mesh->normals, index, (void*)(&normal));
+ 	vec4_t normal4 = { normal.x, normal.y, normal.z, 0 };
+ 	buf_set_at(mesh->normals, index, &normal4);
 	CALLTRACE_END();
 }
 
@@ -618,7 +622,7 @@ RENDERER_API function_signature(void, mesh3d_tangents_add, mesh3d_t* mesh, float
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->tangents, __TANGENTS_ARE_NOT_FOUND__);
-	vec3_t n = {x, y, z};
+	vec4_t n = { x, y, z, 0 };
 	buf_push(mesh->tangents, &n);
 	CALLTRACE_END();
 }
@@ -627,7 +631,8 @@ RENDERER_API function_signature(void, mesh3d_tangent_add_vec3, mesh3d_t* mesh, v
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->tangents, __TANGENTS_ARE_NOT_FOUND__);
-	buf_push(mesh->tangents, (void*)(&v));
+	vec4_t v4 = { v.x, v.y, v.z, 0 };
+	buf_push(mesh->tangents, &v4);
 	CALLTRACE_END();
 }
 
@@ -644,7 +649,8 @@ RENDERER_API function_signature(void, mesh3d_tangent_set_vec3, mesh3d_t* mesh, i
 {
 	CALLTRACE_BEGIN();
  	debug_assert__(NULL != mesh->tangents, __TANGENTS_ARE_NOT_FOUND__);
- 	buf_set_at(mesh->tangents, index, (void*)(&tangent));
+ 	vec4_t tangent4 = { tangent.x, tangent.y, tangent.z, 0 };
+ 	buf_set_at(mesh->tangents, index, &tangent4);
 	CALLTRACE_END();
 }
 
@@ -711,7 +717,7 @@ RENDERER_API function_signature(void, mesh3d_color_add, mesh3d_t* mesh, float x,
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->colors, __COLORS_ARE_NOT_FOUND__);
-	vec3_t n = {x, y, z};
+	vec4_t n = {x, y, z, 1 };
 	buf_push(mesh->colors, &n);
 	CALLTRACE_END();
 }
@@ -720,7 +726,8 @@ RENDERER_API function_signature(void, mesh3d_color_add_vec3, mesh3d_t* mesh, vec
 {
 	CALLTRACE_BEGIN();
 	debug_assert__(NULL != mesh->colors, __COLORS_ARE_NOT_FOUND__);
-	buf_push(mesh->colors, (void*)(&v));
+	vec4_t v4 = { v.x, v.y, v.z, 1 };
+	buf_push(mesh->colors, &v4);
 	CALLTRACE_END();
 }
 
@@ -737,7 +744,8 @@ RENDERER_API function_signature(void, mesh3d_color_set_vec3, mesh3d_t* mesh, ind
 {
 	CALLTRACE_BEGIN();
  	debug_assert__(NULL != mesh->colors, __COLORS_ARE_NOT_FOUND__);
- 	buf_set_at(mesh->colors, index, (void*)(&color));
+ 	vec4_t color4 = { color.x, color.y, color.z, 1 };
+ 	buf_set_at(mesh->colors, index, &color4);
 	CALLTRACE_END();
 }
 
@@ -976,38 +984,32 @@ RENDERER_API function_signature(float, mesh3d_uv_get_x, mesh3d_t* mesh, index_t 
 RENDERER_API function_signature(index_t, mesh3d_sizeof_position, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->positions != NULL, __POSITIONS_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->positions));
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_POSITION_SIZE);
 }
 RENDERER_API function_signature(index_t, mesh3d_sizeof_normal, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->normals != NULL, __NORMALS_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->normals));
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_NORMAL_SIZE);
 }
 RENDERER_API function_signature(index_t, mesh3d_sizeof_tangent, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->tangents != NULL, __TANGENTS_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->tangents));
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_TANGENT_SIZE);
 }
 RENDERER_API function_signature(index_t, mesh3d_sizeof_color, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->colors != NULL, __COLORS_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->colors));
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_COLOR_SIZE);
 }
 RENDERER_API function_signature(index_t, mesh3d_sizeof_uv, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->uvs != NULL, __UVS_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->uvs));
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_UV_SIZE);
 }
 RENDERER_API function_signature(index_t, mesh3d_sizeof_index, mesh3d_t* mesh)
 {
 	CALLTRACE_BEGIN();
-	debug_assert__(mesh->triangles != NULL, __TRIANGLES_ARE_NOT_FOUND__);
-	CALLTRACE_RETURN(buf_get_element_size(mesh->triangles) / 3);
+	CALLTRACE_RETURN(MESH3D_VERTEX_ATTRIB_TRIANGLE_SIZE / 3);
 }
 
 RENDERER_API function_signature(mesh3d_t*, mesh3d_plane, memory_allocator_t* allocator, float size)
@@ -1321,9 +1323,9 @@ RENDERER_API function_signature(mesh3d_t*, mesh3d_load, memory_allocator_t* allo
 			BUFFER texcoord_buffer;		// temporary buffer to store texture coordinates
 		} user_data;
 		user_data.mesh = mesh;
-		user_data.normal_buffer = buf_create(sizeof(float) * 3, 0, 0);
-		user_data.position_buffer = buf_create(sizeof(float) * 3, 0, 0);
-		user_data.texcoord_buffer = buf_create(sizeof(float) * 2, 0, 0);
+		user_data.normal_buffer = buf_create(MESH3D_VERTEX_ATTRIB_NORMAL_SIZE, 0, 0);
+		user_data.position_buffer = buf_create(MESH3D_VERTEX_ATTRIB_POSITION_SIZE, 0, 0);
+		user_data.texcoord_buffer = buf_create(MESH3D_VERTEX_ATTRIB_UV_SIZE, 0, 0);
 		obj_parse_callbacks_t parse_callbacks =
 		{
 			.user_data = &user_data,
@@ -1402,13 +1404,15 @@ static void print_facet(u32* facet, u32 attrib_count, u32 face_vertex_count, voi
 static void obj_vertex_normal(float* normal, void* user_data)
 {
 	// print_normal(normal, NULL);
-	buf_push(&((BUFFER*)(user_data + sizeof(mesh3d_t*)))[0], normal);
+	vec4_t n = { normal[0], normal[1], normal[2], 1 };
+	buf_push(&((BUFFER*)(user_data + sizeof(mesh3d_t*)))[0], &n);
 }
 
 static void obj_vertex_position(float* position, void* user_data)
 {
 	// print_position(position, NULL);
-	buf_push(&((BUFFER*)(user_data + sizeof(mesh3d_t*)))[1], position);
+	vec4_t p = { position[0], position[1], position[2], 0 };
+	buf_push(&((BUFFER*)(user_data + sizeof(mesh3d_t*)))[1], &p);
 }
 
 static void obj_vertex_texcoord(float* texcoord, void* user_data)

--- a/source/renderer/shader_library.c
+++ b/source/renderer/shader_library.c
@@ -135,13 +135,13 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_info(vulkan_rend
 		case SHADER_LIBRARY_SHADER_PRESET_UNLIT_COLOR:
 		case SHADER_LIBRARY_SHADER_PRESET_SKYBOX:
 		case SHADER_LIBRARY_SHADER_PRESET_SHADOW_MAP:
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
 			break;
 		case SHADER_LIBRARY_SHADER_PRESET_UNLIT_UI:
 		case SHADER_LIBRARY_SHADER_PRESET_UNLIT_UI2:
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
 			begin_vertex_binding(renderer, &attributes, 8, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_TEXCOORD_BINDING);
@@ -155,19 +155,19 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_info(vulkan_rend
 		case SHADER_LIBRARY_SHADER_PRESET_POINT_LIGHT:
 		case SHADER_LIBRARY_SHADER_PRESET_SPOT_LIGHT:
 		case SHADER_LIBRARY_SHADER_PRESET_LIT_SHADOW_COLOR:
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16 /* 12 + 1 padding */, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16 /* 12 + 1 padding */, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
 			break;
 		case SHADER_LIBRARY_SHADER_PRESET_DIFFUSE_TEST:
 		case SHADER_LIBRARY_SHADER_PRESET_DIFFUSE_POINT:
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16 /* 12 + 1 padding */, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_POSITION_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
-			begin_vertex_binding(renderer, &attributes, 12, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_BINDING);
+			begin_vertex_binding(renderer, &attributes, 16 /* 12 + 1 padding */, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_BINDING);
 				add_vertex_attribute(&attributes, VULKAN_MESH_VERTEX_ATTRIBUTE_NORMAL_LOCATION, VK_FORMAT_R32G32B32_SFLOAT, 0);
 			end_vertex_binding(renderer, &attributes);
 			begin_vertex_binding(renderer, &attributes, 8, VK_VERTEX_INPUT_RATE_VERTEX, VULKAN_MESH_VERTEX_ATTRIBUTE_TEXCOORD_BINDING);

--- a/source/renderer/vulkan/vulkan_descriptor_set_layout.c
+++ b/source/renderer/vulkan/vulkan_descriptor_set_layout.c
@@ -79,7 +79,7 @@ RENDERER_API void vulkan_descriptor_set_layout_create_from_resource_descriptors_
 		vulkan_shader_resource_description_t* descriptor = &descriptors[i];
 
 		// if this is a push constant range or a vertex attribute then skip it
-		if(descriptor->is_push_constant || descriptor->is_attribute)
+		if(descriptor->is_push_constant || vulkan_shader_resource_description_is_attribute(descriptor))
 			continue;
 
 		VkDescriptorSetLayoutBinding* binding = &bindings[binding_count];

--- a/source/renderer/vulkan/vulkan_material.c
+++ b/source/renderer/vulkan/vulkan_material.c
@@ -65,7 +65,7 @@ static void setup_material_resources(vulkan_material_t* material)
 	for(u16 i = 0, j = 0; i < material->shader->material_set_binding_count; i++)
 	{
 		vulkan_shader_resource_description_t* binding = &bindings[i];
-		if(binding->is_attribute || binding->is_opaque || binding->is_push_constant)
+		if(vulkan_shader_resource_description_is_attribute(binding) || binding->is_opaque || binding->is_push_constant)
 			continue;
 
 		_debug_assert__(j < count);
@@ -637,7 +637,7 @@ RENDERER_API vulkan_material_field_handle_t vulkan_material_get_field_handle(vul
 	for(u16 i = 0, j = 0; i < binding_count; i++)
 	{
 		vulkan_shader_resource_description_t* binding = &bindings[i];
-		if(binding->is_attribute)
+		if(vulkan_shader_resource_description_is_attribute(binding))
 			continue;
 		if(strcmp(binding->handle.name, struct_name) == 0)
 		{

--- a/source/renderer/vulkan/vulkan_shader.c
+++ b/source/renderer/vulkan/vulkan_shader.c
@@ -259,7 +259,7 @@ static vulkan_vertex_buffer_layout_description_t* create_deep_copy_of_vulkan_ver
 
 		memcopyv(copy_infos[i].attribute_formats, vertex_infos[i].attribute_formats, VkFormat, attribute_count);
 		memcopyv(copy_infos[i].attribute_offsets, vertex_infos[i].attribute_offsets, u32, attribute_count);
-		memcopyv(copy_infos[i].attribute_locations, vertex_infos[i].attribute_locations, u16, attribute_count);
+		memcopyv(copy_infos[i].attribute_locations, vertex_infos[i].attribute_locations, u32, attribute_count);
 	}
 	return copy_infos;
 }
@@ -1101,7 +1101,7 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_infos(memory_all
 	vulkan_vertex_buffer_layout_description_t* vertex_infos = memory_allocator_alloc_obj_array(allocator, MEMORY_ALLOCATION_TYPE_OBJ_VK_VERTEX_BUFFER_LAYOUT_DESCRIPTION_ARRAY, vulkan_vertex_buffer_layout_description_t, descriptor_count);
 	safe_memzerov(vertex_infos, vulkan_vertex_buffer_layout_description_t, descriptor_count);
 
-	typedef struct attribute_info_t { BUFFER locations, formats, offsets; } attribute_info_t;
+	typedef struct attribute_info_t { BUFFER locations, formats, offsets; u32 largest_element_size; } attribute_info_t;
 	dictionary_t bindings = dictionary_create(u32, attribute_info_t, 1, dictionary_key_comparer_u32);
 
 	// iterate through each vertex attribute across all the vertex bindings
@@ -1109,12 +1109,6 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_infos(memory_all
 	{
 		// this must be an attribute
 		_debug_assert__(vulkan_shader_resource_description_is_attribute(&descriptors[i]));
-
-		u32 location = descriptors[i].vertex_attrib_location_number;
-		glsl_type_t glsl_type = descriptors[i].handle.type;
-		VkFormat format = vkformatof_glsl_type(glsl_type);
-		u32 alignment = alignof_glsl_type(glsl_type);
-		u32 size = sizeof_glsl_type(glsl_type);
 
 		// use vertex binding number as a key
 		u32 key = descriptors[i].vertex_attrib_binding_number;
@@ -1125,7 +1119,8 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_infos(memory_all
 			{ 
 				.locations = buf_create(sizeof(u32), 1, 0), 
 				.formats = buf_create(sizeof(VkFormat), 1, 0), 
-				.offsets = buf_create(sizeof(u32), 1, 0) 
+				.offsets = buf_create(sizeof(u32), 1, 0),
+				.largest_element_size = 0
 			};
 			dictionary_push(&bindings, &key, &info);
 
@@ -1145,23 +1140,33 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_infos(memory_all
 		// get pointer to the attribute info object for binding 'key'
 		attribute_info_t* attribute_info = dictionary_get_value_ptr(&bindings, &key);
 
+		u32 location = descriptors[i].vertex_attrib_location_number;
+
 		// TODO: These checks should be done at the compilation time, not at the runtime
 		if(buf_find_index_of(&attribute_info->locations, &location, buf_u32_comparer) != BUF_INVALID_INDEX)
 			LOG_FETAL_ERR("Multiple vertex attributes have the same layout location \"%u\", which is not allowed!\n", location);
 			
 		// add the location
 		buf_push(&attribute_info->locations, &location);
+		
+		glsl_type_t glsl_type = descriptors[i].handle.type;
+		
 		// add the format
+		VkFormat format = vkformatof_glsl_type(glsl_type);
 		buf_push(&attribute_info->formats, &format);
 
 		u32 offset;
 		// pop the previous offset
 		buf_pop(&attribute_info->offsets, &offset);
 		// snap the offset to the correct alignment for this field/attribute
+		u32 alignment = alignof_glsl_type(glsl_type);
 		offset += (alignment - (offset % alignment)) % alignment;
 		// add the offset
 		buf_push(&attribute_info->offsets, &offset);
 		// increment the offset by the size of this field/attribute
+		u32 size = sizeof_glsl_type(glsl_type);
+		if(max(alignment, size) > attribute_info->largest_element_size)
+			attribute_info->largest_element_size = max(alignment, size);
 		offset += size;
 		// save the offset for next iteration
 		buf_push(&attribute_info->offsets, &offset);
@@ -1174,13 +1179,14 @@ static vulkan_vertex_buffer_layout_description_t* create_vertex_infos(memory_all
 		attribute_info_t* ainfo = dictionary_get_value_ptr_at(&bindings, i);
 
 		// the final stride would be the last saved offset
-		vinfo->size = *(u32*)buf_peek_ptr(&ainfo->offsets);
+		u32 offset = *(u32*)buf_peek_ptr(&ainfo->offsets);
+		vinfo->size = offset + (ainfo->largest_element_size - offset % ainfo->largest_element_size) % ainfo->largest_element_size;
 		// assign the number of attribute count
 		vinfo->attribute_count = buf_get_element_count(&ainfo->locations);
 		// assign the internal pointers to their corresponding destinations
-		vinfo->attribute_locations = buf_get_ptr(&ainfo->locations);
-		vinfo->attribute_formats = buf_get_ptr(&ainfo->formats);
-		vinfo->attribute_offsets = buf_get_ptr(&ainfo->offsets);
+		vinfo->attribute_locations = CAST_TO(u32*, buf_get_ptr(&ainfo->locations));
+		vinfo->attribute_formats = CAST_TO(VkFormat*, buf_get_ptr(&ainfo->formats));
+		vinfo->attribute_offsets = CAST_TO(u32*, buf_get_ptr(&ainfo->offsets));
 	}
 
 	// set the number of bindings

--- a/source/renderer/vulkan/vulkan_vertex_buffer_layout_description.c
+++ b/source/renderer/vulkan/vulkan_vertex_buffer_layout_description.c
@@ -47,7 +47,7 @@ RENDERER_API void vulkan_vertex_buffer_layout_description_begin(vulkan_renderer_
 	description->input_rate = input_rate;
 	description->size = stride;
 
-	description->attribute_locations = CAST_TO(u16*, create_buffer(renderer->allocator, u16));
+	description->attribute_locations = CAST_TO(u32*, create_buffer(renderer->allocator, u32));
 	description->attribute_formats = CAST_TO(VkFormat*, create_buffer(renderer->allocator, VkFormat));
 	description->attribute_offsets = CAST_TO(u32*, create_buffer(renderer->allocator, u32));
 }

--- a/source/test.c
+++ b/source/test.c
@@ -44,6 +44,7 @@
 
 #include <renderer/tests/cube.h>
 #include <renderer/tests/texture_sampling.h>
+#include <renderer/tests/text_mesh.h>
 
 #include <renderer/tests/TID-14.case1.h>
 #include <renderer/tests/TID-14.case2.h>
@@ -93,6 +94,7 @@ RENDERER_API test_t* test_create(memory_allocator_t* allocator, const char* name
 	ELSE_IF(SPOT_LIGHT_LOAD);
 	ELSE_IF(CUBE);
 	ELSE_IF(TEXTURE_SAMPLING);
+	ELSE_IF(TEXT_MESH);
 	ELSE_IF(TID_14_CASE_1);
 	ELSE_IF(TID_14_CASE_2);
 	ELSE_IF(TID_14_CASE_3);
@@ -126,6 +128,7 @@ RENDERER_API test_t* test_create(memory_allocator_t* allocator, const char* name
 					"\tSPOT_LIGHT_LOAD\n"
 					"\tCUBE\n"
 					"\tTEXTURE_SAMPLING\n"
+					"\tTEXT_MESH\n"
 					"\tTID_14_CASE_1\n"
 					"\tTID_14_CASE_2\n"
 					"\tTID_14_CASE_3\n"

--- a/source/tests/text_mesh.c
+++ b/source/tests/text_mesh.c
@@ -1,3 +1,28 @@
+/*
+	***This is computer generated notice - Do not modify it***
+
+	VulkanRenderer (inclusive of its dependencies and subprojects 
+	such as toolchains written by the same author) is a software to render 
+	2D & 3D geometries by writing C/C++ code and shaders.
+
+	File: text_mesh.c is a part of VulkanRenderer
+
+	Copyright (C) 2023  Author: Ravi Prakash Singh
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
 
 /*
 	test id: TEXT_MESH

--- a/source/tests/text_mesh.c
+++ b/source/tests/text_mesh.c
@@ -1,0 +1,121 @@
+
+/*
+	test id: TEXT_MESH
+	Test to check if text mesh is working fine
+ */
+
+#include <renderer/tests/text_mesh.h>
+
+#define RENDERER_INCLUDE_MATH
+#define RENDERER_INCLUDE_3D_TEXT_RENDER_SYSTEM
+#define RENDERER_INCLUDE_CORE
+#include <renderer/renderer.h>
+
+#include <conio.h>
+
+TEST_DATA(TEXT_MESH)
+{
+	render_scene_t* scene;
+
+	camera_t* camera;
+
+	glyph_mesh_pool_t* glyph_pool;
+	font_t* font;
+
+	text_mesh_t* text_mesh;
+	text_mesh_string_handle_t string_handle;
+
+	render_object_t* render_object;
+	material_t* material;
+
+	int isScreenSpace; /* bools are not support currently in V3DShader (see: TID64)*/
+};
+
+
+SETUP_TEST(TEXT_MESH);
+
+TEST_ON_RENDERER_INITIALIZE(TEXT_MESH)
+{
+	return (renderer_initialization_data_t)
+	{
+		.window_name = "TEXT_MESH (press any key to switch from Screen space to World space and vice versa",
+		.window_width = 800,
+		.window_height = 800,
+		.is_resizable = true,
+		.is_fullscreen = false
+	};
+}
+
+TEST_ON_INITIALIZE(TEXT_MESH)
+{
+	AUTO camera_system = renderer_get_camera_system(renderer);
+	AUTO slib = renderer_get_shader_library(renderer);
+	AUTO mlib = renderer_get_material_library(renderer);
+
+	this->camera = camera_system_getH(camera_system,
+		camera_system_create_camera(camera_system, CAMERA_PROJECTION_TYPE_PERSPECTIVE));
+	camera_set_clear(this->camera, COLOR_GREEN, 1.0f);
+	camera_set_active(this->camera, true);
+	camera_set_transform(this->camera, mat4_mul(2, mat4_translation(-1.8f, 0.6f, 0), mat4_rotation(0, 0, -22 * DEG2RAD)));
+
+	this->scene = render_scene_create_from_mask(renderer, BIT64(RENDER_QUEUE_TYPE_GEOMETRY));
+
+	this->material = material_library_getH(mlib, 
+							material_library_create_materialH(mlib, 
+							shader_library_load_shader(slib, 
+								"shaders/builtins/text_shader.sb"), "MyMaterial"));
+	this->isScreenSpace = 1;
+	material_set_int(this->material, "parameters.isScreenSpace", 1);
+
+	this->font = font_load_and_create(renderer->allocator, "showcase/resource/fonts/arial.ttf");
+	this->glyph_pool = glyph_mesh_pool_create(renderer, this->font);
+	this->text_mesh = text_mesh_create(renderer, this->glyph_pool);
+	this->string_handle = text_mesh_string_create(this->text_mesh);
+	text_mesh_string_setH(this->text_mesh, this->string_handle, "Screen Space");
+
+	this->render_object = render_scene_getH(this->scene, render_scene_create_object(this->scene, RENDER_OBJECT_TYPE_TEXT_MESH, RENDER_QUEUE_TYPE_GEOMETRY));
+	render_object_set_material(this->render_object, this->material);
+	render_object_attach(this->render_object, this->text_mesh);
+	render_object_set_transform(this->render_object, mat4_translation(0.0f, 0.0f, -3.0f));
+
+	render_scene_build_queues(this->scene);
+
+}
+
+TEST_ON_TERMINATE(TEXT_MESH)
+{
+	text_mesh_destroy(this->text_mesh);
+	text_mesh_release_resources(this->text_mesh);
+	font_destroy(this->font);
+	font_release_resources(this->font);
+	glyph_mesh_pool_destroy(this->glyph_pool);
+	glyph_mesh_pool_release_resources(this->glyph_pool);
+	render_scene_destroy(this->scene);
+	render_scene_release_resources(this->scene);
+}
+
+
+TEST_ON_UPDATE(TEXT_MESH)
+{
+	if(kbhit())
+	{
+		getch();
+		this->isScreenSpace = !this->isScreenSpace;
+		material_set_int(this->material, "parameters.isScreenSpace", this->isScreenSpace);
+		switch(this->isScreenSpace)
+		{
+			case 0:
+				text_mesh_string_setH(this->text_mesh, this->string_handle, "World Space");
+				break;
+			case 1:
+				text_mesh_string_setH(this->text_mesh, this->string_handle, "Screen Space");
+				break;
+		}
+	}
+}
+
+TEST_ON_RENDER(TEXT_MESH)
+{
+	render_scene_render(this->scene, RENDER_SCENE_ALL_QUEUES, RENDER_SCENE_CLEAR);
+}
+


### PR DESCRIPTION
- added another unit test TEXT_MESH
- Fixed vertex buffer layout setup for text_mesh_t and mest_t
- Now the element size of position, normal, color, and tangent has been increased to sizeof(float) * 4 (previously it was sizeof(float) * 3).