### PR TITLE
Text mesh layout handler

### DIFF
--- a/include/renderer/internal/vulkan/vulkan_text_mesh.h
+++ b/include/renderer/internal/vulkan/vulkan_text_mesh.h
@@ -106,6 +106,7 @@
 #include <bufferlib/buffer.h>
 #include <renderer/dictionary.h>
 #include <renderer/internal/vulkan/vulkan_host_buffered_buffer.h>
+#include <renderer/internal/vulkan/vulkan_text_types.h>
 #include <glslcommon/glsl_types.h>
 
 typedef struct vulkan_text_mesh_glsl_glyph_render_data_t
@@ -138,6 +139,30 @@ typedef buf_ucount_t vulkan_text_mesh_string_handle_t;
 typedef dictionary_t /* (u16, sub_buffer_handle_t) */ vulkan_text_mesh_glyph_render_data_sub_buffer_handle_list_t;
 typedef buffer_t vulkan_text_mesh_string_char_buffer_t;
 
+/* <begin> typedefs facilitating text layout */
+
+typedef vulkan_text_glyph_layout_data_t vulkan_text_mesh_glyph_layout_data_t;
+
+typedef vulkan_text_glyph_layout_data_buffer_t vulkan_text_mesh_glyph_layout_data_buffer_t;
+
+typedef vulkan_text_glyph_info_t vulkan_text_mesh_glyph_info_t;
+
+typedef vulkan_text_glyph_layout_handler_input_data_t vulkan_text_mesh_glyph_layout_handler_input_data_t;
+
+typedef vulkan_text_glyph_layout_handler_t vulkan_text_mesh_glyph_layout_handler_t;
+
+typedef vulkan_text_glyph_strikethrough_handler_t vulkan_text_mesh_glyph_strikethrough_handler_t;
+
+typedef vulkan_text_glyph_strikethrough_handler_t vulkan_text_mesh_glyph_strikethrough_handler_t;
+
+typedef vulkan_text_glyph_underline_handler_t vulkan_text_mesh_glyph_underline_handler_t;
+
+typedef vulkan_text_glyph_layout_handler_void_ptr_pair_t vulkan_text_mesh_glyph_layout_handler_void_ptr_pair_t;
+typedef vulkan_text_glyph_strikethrough_handler_void_ptr_pair_t vulkan_text_mesh_glyph_strikethrough_handler_void_ptr_pair_t;
+typedef vulkan_text_glyph_underline_handler_void_ptr_pair_t vulkan_text_mesh_glyph_underline_handler_void_ptr_pair_t;
+
+/* <end> typedefs facilitating text layout */
+
 typedef struct vulkan_text_mesh_string_t
 {
 	vulkan_text_mesh_string_handle_t next_handle;
@@ -160,9 +185,23 @@ typedef struct vulkan_text_mesh_t
 {
 	vulkan_renderer_t* renderer;
 	vulkan_material_t* material;
+	u32 point_size;
 	vulkan_text_mesh_render_space_type_t render_space_type;
 	vulkan_text_mesh_render_surface_type_t render_surface_type;
-	u32 point_size;
+
+	/* <begin> fields facilitating text layout */
+
+		/* called whenever vulkan_text_mesh_string_setH is called */
+		vulkan_text_mesh_glyph_layout_handler_void_ptr_pair_t glyph_layout_handler;
+		/* called whenever vulkan_text_mesh_glyph_layout_data_t::is_strikethrough is true */
+		vulkan_text_mesh_glyph_strikethrough_handler_void_ptr_pair_t glyph_strikethrough_handler;
+		/* called whenever vulkan_text_mesh_glyph_layout_data_t::is_underline is true */
+		vulkan_text_mesh_glyph_underline_handler_void_ptr_pair_t glyph_underline_handler;
+
+		/* holds post processed info for each glyph */
+		vulkan_text_mesh_glyph_layout_data_buffer_t glyph_layout_data_buffer;
+
+	/* <end> fields facilitating text layout */
 
 	/* CPU side */
 	vulkan_glyph_mesh_pool_t* pool;												// pool from which the mesh_t should be queried from for a particular glyph
@@ -192,6 +231,9 @@ RENDERER_API vulkan_text_mesh_string_handle_t vulkan_text_mesh_string_create(vul
 RENDERER_API void vulkan_text_mesh_string_destroyH(vulkan_text_mesh_t* text_mesh, vulkan_text_mesh_string_handle_t handle);
 
 // setters
+RENDERER_API void vulkan_text_mesh_set_glyph_layout_handler(vulkan_text_mesh_t* text, vulkan_text_mesh_glyph_layout_handler_t handler, void* user_data);
+RENDERER_API void vulkan_text_mesh_set_glyph_strikethrough_handler(vulkan_text_mesh_t* text, vulkan_text_mesh_glyph_strikethrough_handler_t handler, void* user_data);
+RENDERER_API void vulkan_text_mesh_set_glyph_underline_handler(vulkan_text_mesh_t* text, vulkan_text_mesh_glyph_underline_handler_t handler, void* user_data);
 RENDERER_API void vulkan_text_mesh_set_point_size(vulkan_text_mesh_t* text_mesh, u32 point_size);
 RENDERER_API void vulkan_text_mesh_set_material(vulkan_text_mesh_t* text_mesh, vulkan_material_t* material);
 RENDERER_API void vulkan_text_mesh_set_render_space_type(vulkan_text_mesh_t* text, vulkan_text_mesh_render_space_type_t space_type);

--- a/include/renderer/internal/vulkan/vulkan_text_types.h
+++ b/include/renderer/internal/vulkan/vulkan_text_types.h
@@ -11,9 +11,8 @@
 /* holds the post processed layout data for each glyph */
 typedef struct vulkan_text_glyph_layout_data_t
 {
-	/* unicode of the glyph,
-	 * note that not all glyphs may survive to the final post processed glyphs buffer (vulkan_text_mesh_glyph_layout_data_buffer_t)*/
-	utf32_t unicode;
+	/* index of the glyph in the string */
+	u32 index;
 	/* offset added to this glyph, in pixel coordinates if space is 2D, otherwise in world coordinates */
 	vec3_t offset;
 	/* color of this glyph (8 bit per component)*/

--- a/include/renderer/internal/vulkan/vulkan_text_types.h
+++ b/include/renderer/internal/vulkan/vulkan_text_types.h
@@ -11,6 +11,9 @@
 /* holds the post processed layout data for each glyph */
 typedef struct vulkan_text_glyph_layout_data_t
 {
+	/* unicode of the glyph,
+	 * note that not all glyphs may survive to the final post processed glyphs buffer (vulkan_text_mesh_glyph_layout_data_buffer_t)*/
+	utf32_t unicode;
 	/* offset added to this glyph, in pixel coordinates if space is 2D, otherwise in world coordinates */
 	vec3_t offset;
 	/* color of this glyph (8 bit per component)*/

--- a/source/renderer/font.c
+++ b/source/renderer/font.c
@@ -272,6 +272,7 @@ RENDERER_API void font_get_glyph_mesh(font_t* font, utf32_t unicode, u8 mesh_qua
 RENDERER_API void font_get_glyph_info(font_t* font, utf32_t unicode, font_glyph_info_t* out_info)
 {
 	int index = ttf_find_glyph(font->ttf_handle, unicode);
+	out_info->is_graph = isgraph(CAST_TO(s32, unicode)) != 0;
 	if(index < 0)
 	{
 		LOG_FETAL_ERR("Font error: couldn't find glyph \"%c\"\n", unicode);

--- a/source/renderer/vulkan/vulkan_bitmap_text.c
+++ b/source/renderer/vulkan/vulkan_bitmap_text.c
@@ -77,7 +77,23 @@ static void update_bga_and_gtc_buffer(void* publisher, void* handler_data)
 
 static bool default_glyph_layout_handler(vulkan_bitmap_text_glyph_layout_data_buffer_t* output, const vulkan_bitmap_text_glyph_layout_handler_input_data_t* input, void* user_data)
 {
-	return false;
+	u32 count = input->glyph_count;
+	for(u32 i = 0; i < count; i++)
+	{
+		vulkan_bitmap_text_glyph_layout_data_t data =
+		{
+			.unicode = input->glyphs[i].unicode,
+			.offset = { 0, 0, 0 },
+			.color = ICOLOR4_GREY,
+			.is_bold = false,
+			.is_italic = false,
+			.is_strikethrough = false,
+			.is_underline = false,
+			.idoc = NULL
+		};
+		buf_push(output, &data);
+	}
+	return true;
 }
 
 RENDERER_API void vulkan_bitmap_text_create_no_alloc(vulkan_renderer_t* renderer, vulkan_bitmap_text_create_info_t* create_info, vulkan_bitmap_text_t OUT text)

--- a/source/renderer/vulkan/vulkan_bitmap_text.c
+++ b/source/renderer/vulkan/vulkan_bitmap_text.c
@@ -82,7 +82,7 @@ static bool default_glyph_layout_handler(vulkan_bitmap_text_glyph_layout_data_bu
 	{
 		vulkan_bitmap_text_glyph_layout_data_t data =
 		{
-			.unicode = input->glyphs[i].unicode,
+			.index = i,
 			.offset = { 0, 0, 0 },
 			.color = ICOLOR4_GREY,
 			.is_bold = false,
@@ -531,17 +531,19 @@ static void text_string_set(vulkan_bitmap_text_t* text, vulkan_bitmap_text_strin
 
 	for(u32 i = 0; i < final_count; i++)
 	{
+		AUTO glyph_data = is_changed ? buf_get_ptr_at_typeof(&text->glyph_layout_data_buffer, vulkan_bitmap_text_glyph_layout_data_t, i) : NULL;
+		u32 index = is_changed ? glyph_data->index : i;
+
 		/* skip the whitespaces (for which we don't have any physical texture coord information) */
-		if(texcoord_indices[i] == U32_MAX)
+		if(texcoord_indices[index] == U32_MAX)
 			continue;
 
-		AUTO glyph_data = is_changed ? buf_get_ptr_at_typeof(&text->glyph_layout_data_buffer, vulkan_bitmap_text_glyph_layout_data_t, i) : NULL;
-		AUTO offset = vec3_add(2, glyph_infos[i].rect.offset, (is_changed ? glyph_data->offset : vec3_zero()));
+		AUTO offset = vec3_add(2, glyph_infos[index].rect.offset, (is_changed ? glyph_data->offset : vec3_zero()));
 		// _debug_assert__(info.bitmap_top == info.bearing_y);
 		vulkan_bitmap_text_glsl_glyph_render_data_t data =
 		{
 			.ofst = { offset.x, offset.y, offset.z },
-			.indx = texcoord_indices[i],
+			.indx = texcoord_indices[index],
 			/* TODO: Remove this as we don't need this level of flexibility */
 			.rotn = { ((i%3) == 0) ? 1 : 0, ((i%3) == 1) ? 1 : 0, ((i%3) == 2) ? 1 : 0 },
 			.stid = U64_TO_U32(text_string->handle),

--- a/source/renderer/vulkan/vulkan_text_mesh.c
+++ b/source/renderer/vulkan/vulkan_text_mesh.c
@@ -73,7 +73,7 @@ static bool default_glyph_layout_handler(vulkan_text_mesh_glyph_layout_data_buff
 	{
 		vulkan_text_mesh_glyph_layout_data_t data =
 		{
-			.unicode = input->glyphs[i].unicode,
+			.index = i,
 			.offset = { 0, 0, 0 },
 			.color = ICOLOR4_GREY,
 			.is_bold = false,
@@ -400,7 +400,6 @@ RENDERER_API void vulkan_text_mesh_string_setH(vulkan_text_mesh_t* text_mesh, vu
 	/* prepare glyph infos to be fed into the layout handler */
 
 	vulkan_text_mesh_glyph_info_t glyph_infos[len];
-	u32 texcoord_indices[len];
 
 	f32 horizontal_pen = 0.0f;
 	for(u32 i = 0; i < len; i++)
@@ -433,12 +432,13 @@ RENDERER_API void vulkan_text_mesh_string_setH(vulkan_text_mesh_t* text_mesh, vu
 	/* final (post-processed) glyph counts */
 	u32 final_count = is_changed ? buf_get_element_count(&text_mesh->glyph_layout_data_buffer) : len;
 
-	_debug_assert__((!is_changed) || (is_changed && (final_count == len)));
+	_debug_assert__(is_changed || ((!is_changed) && (final_count == len)));
 
 	for(u32 i = 0; i < final_count; i++)
 	{
 		AUTO glyph_data = is_changed ? buf_get_ptr_at_typeof(&text_mesh->glyph_layout_data_buffer, vulkan_text_mesh_glyph_layout_data_t, i) : NULL;
-		utf32_t unicode = is_changed ? glyph_data->unicode : glyph_infos[i].unicode;
+		u32 index = is_changed ? glyph_data->index : i;
+		utf32_t unicode = glyph_infos[index].unicode;
 		_debug_assert__(unicode != 0);
 		if(!isgraph(CAST_TO(s32, unicode)))
 			continue;
@@ -462,7 +462,7 @@ RENDERER_API void vulkan_text_mesh_string_setH(vulkan_text_mesh_t* text_mesh, vu
 		}
 
 		/* calculate the final offset */
-		AUTO offset = vec3_add(2, glyph_infos[i].rect.offset, _offset);
+		AUTO offset = vec3_add(2, glyph_infos[index].rect.offset, _offset);
 
 		/* add the glyph render data to the render buffer */
 		vulkan_text_mesh_glsl_glyph_render_data_t data =

--- a/source/tests/bitmap_text.c
+++ b/source/tests/bitmap_text.c
@@ -753,9 +753,9 @@ TEST_ON_UPDATE(BITMAP_TEXT)
 	counter = 0;
 	char buffer[128] =  { };
 	sprintf(buffer, "%d", counter);
-	// bitmap_text_string_setH(this->text, this->text_string_handle, buffer);
+	bitmap_text_string_setH(this->text, this->text_string_handle, buffer);
 	sprintf(buffer, "%d", counter);
-	// bitmap_text_string_setH(this->text, this->another_string_handle, buffer);
+	bitmap_text_string_setH(this->text, this->another_string_handle, buffer);
 
 	bitmap_glyph_atlas_texture_commit(this->texture, NULL);
 }


### PR DESCRIPTION
Implement text mesh layout handler, identical to bitmap text layout handler. 

However, currently if the handler skips any character/glyph then the vacant space won't be occupied by the adjacent glyphs on the either side. 
Let's keep this task for some time in future.