### PR TITLE
Wrap path must have path relative to the subprojects dir

### DIFF
--- a/subprojects/shader_compiler.wrap
+++ b/subprojects/shader_compiler.wrap
@@ -1,5 +1,5 @@
 [wrap-path]
-path = toolchain/shader_compiler
+path = ../toolchain/shader_compiler
 
 [provide]
 shader_compiler = shader_compiler_static_dep


### PR DESCRIPTION
Made changes to [wrap-path] files according to changes in forked meson, here: https://github.com/ravi688/meson/commit/aadb528d440171e73e20bf3d787d732664aa5d34